### PR TITLE
fix: LEAP-14: Don't validate items in async Taxonomy

### DIFF
--- a/label_studio_tools/core/label_config.py
+++ b/label_studio_tools/core/label_config.py
@@ -76,7 +76,7 @@ def parse_config(config_string):
                     }
             if conditionals:
                 tag_info['conditionals'] = conditionals
-            if has_variable(tag.attrib.get("value", "")):
+            if has_variable(tag.attrib.get("value", "")) or has_variable(tag.attrib.get("apiUrl", "")):
                 tag_info['dynamic_labels'] = True
             outputs[tag.attrib['name']] = tag_info
         elif _is_input_tag(tag):

--- a/label_studio_tools/core/label_config.py
+++ b/label_studio_tools/core/label_config.py
@@ -76,7 +76,7 @@ def parse_config(config_string):
                     }
             if conditionals:
                 tag_info['conditionals'] = conditionals
-            if has_variable(tag.attrib.get("value", "")) or has_variable(tag.attrib.get("apiUrl", "")):
+            if has_variable(tag.attrib.get("value", "")) or tag.attrib.get("apiUrl"):
                 tag_info['dynamic_labels'] = True
             outputs[tag.attrib['name']] = tag_info
         elif _is_input_tag(tag):


### PR DESCRIPTION
They are like dynamic values, but completely uncontrolled, so can't be checked.